### PR TITLE
Use the log4j-1.2 API bridge to remove log4j-1.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,22 @@
       <groupId>net.sourceforge.stripes</groupId>
       <artifactId>stripes</artifactId>
       <version>1.6.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.taglibs</groupId>


### PR DESCRIPTION
Log4j 1.2.17 is a transitive dependency of Commons Logging 1.1.3, which itself is a transitive dependency of Stripes 1.6.0. 

```maven
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ jpetstore ---
[INFO] org.mybatis:jpetstore:war:6.0.3-SNAPSHOT
...
[INFO] +- net.sourceforge.stripes:stripes:jar:1.6.0:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  \- log4j:log4j:jar:1.2.17:compile
```

Given the recent log4j vulnerabilities that affect the 1.2.x version, it seemed like a good idea to remove the dependency so developers could rely on the newer (presumably safer) version.