### PR TITLE
[pom] Remove commons-logging for jcl-over-sfl4j and remove log4j 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
       <groupId>net.sourceforge.stripes</groupId>
       <artifactId>stripes</artifactId>
       <version>1.6.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.taglibs</groupId>
@@ -108,6 +118,11 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <version>4.0.4</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.32</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -161,6 +176,12 @@
       <artifactId>htmlunit-driver</artifactId>
       <version>3.56.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
Addresses #498 by removing log4j and commons-logging instead and adding in jcl-over-slf4j as project was using slf4j-api/slf4j-simple.