### PR TITLE
fix: rm mysql and restore to in-memory database

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=password
+MYSQL_URL=jdbc:mysql://mysql:3306/JpetStore

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,0 @@
-MYSQL_USERNAME=root
-MYSQL_PASSWORD=password
-MYSQL_URL=jdbc:mysql://mysql:3306/JpetStore

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,33 +18,9 @@ version: "3.9"
 
 services:
   jpetstore:
-    container_name: jpetstore-test
+    container_name: jpetstore
     build:
       context: .
-    depends_on:
-      mysql: 
-        condition: service_healthy
     ports:
-      - 9050:8080
+      - 8080:8080
     restart: always
-
-  mysql:
-    image: mysql:8
-    volumes:
-      - db_data:/var/lib/mysql
-      - ./src/main/resources/database/jpetstore-hsqldb-data.sql:/docker-entrypoint-initdb.d/init.sql
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_USER: ${MYSQL_USERNAME}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: JPetStore
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 3s
-    restart: always
-
-volumes:
-  db_data:

--- a/pom.xml
+++ b/pom.xml
@@ -57,18 +57,6 @@
   </distributionManagement>
 
   <dependencies>
-
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.32</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
-      <version>2.9.0</version>
-    </dependency>
     
     <dependency>
       <groupId>org.mybatis</groupId>

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -28,16 +28,10 @@
      http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
      http://mybatis.org/schema/mybatis-spring http://mybatis.org/schema/mybatis-spring.xsd">
 
-    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-        <property name="url" value="${MYSQL_URL}" />
-        <property name="username" value="${MYSQL_USERNAME}" />
-        <property name="password" value="${MYSQL_PASSWORD}" />
-    </bean>
-    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="location" value="file:../../../../.env" />
-    </bean>
-
+    <jdbc:embedded-database id="dataSource">
+        <jdbc:script location="classpath:database/jpetstore-hsqldb-schema.sql"/>
+        <jdbc:script location="classpath:database/jpetstore-hsqldb-dataload.sql"/>
+    </jdbc:embedded-database>
 
     <!-- transaction manager, use DataSourceTransactionManager" for JDBC local tx -->
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">


### PR DESCRIPTION
https://github.com/mybatis/jpetstore-6/pull/670

sorry for late reply, i finally fixed the commits.
basically i removed the personal adjustments and changed back the database from mysql to in-memory database
so now you can build the docker image cleanly without .env for mysql container
